### PR TITLE
Tidy up the sanitizeName function and fix a bug

### DIFF
--- a/src/MCPClient/lib/clientScripts/sanitize_names.py
+++ b/src/MCPClient/lib/clientScripts/sanitize_names.py
@@ -23,6 +23,7 @@
 
 import string
 import os
+import re
 from shutil import move as rename
 import sys
 import unicodedata
@@ -30,21 +31,15 @@ from unidecode import unidecode
 from archivematicaFunctions import strToUnicode, unicodeToStr
 
 VERSION = "1.10." + "$Id$".split(" ")[1]
-valid = "-_.()" + string.ascii_letters + string.digits
-replacementChar = "_"
+
+# Letters, digits and a few punctuation characters
+ALLOWED_CHARS = re.compile(r'[^a-zA-Z0-9\-_.\(\)]')
+REPLACEMENT_CHAR = "_"
 
 
 def sanitizeName(basename):
-    ret = ""
-    # We get a more meaningful name sanitization if UTF-8 names
-    # are correctly decoded to unistrings instead of str
-    basename = unidecode(strToUnicode(basename))
-    for c in basename:
-        if c in valid:
-            ret += c
-        else:
-            ret += replacementChar
-    return ret.encode('utf-8')
+    unicode_name = unidecode(strToUnicode(basename))
+    return ALLOWED_CHARS.sub("_", unicode_name)
 
 
 class RenameFailed(Exception):
@@ -65,7 +60,7 @@ def sanitizePath(path):
         sanitizedName = os.path.join(dirname, fileTitle + fileExtension)
 
         while os.path.exists(sanitizedName):
-            sanitizedName = os.path.join(dirname, fileTitle + replacementChar + str(n) + fileExtension)
+            sanitizedName = os.path.join(dirname, fileTitle + REPLACEMENT_CHAR + str(n) + fileExtension)
             n += 1
         exit_status = rename(path, sanitizedName)
         if exit_status:

--- a/src/MCPClient/lib/clientScripts/sanitize_names.py
+++ b/src/MCPClient/lib/clientScripts/sanitize_names.py
@@ -59,7 +59,7 @@ class RenameFailed(Exception):
         self.code = code
 
 
-def sanitizePath(job, path):
+def sanitizePath(path):
     basename = os.path.basename(path)
     dirname = os.path.dirname(path)
     sanitizedName = sanitizeName(basename)
@@ -81,18 +81,18 @@ def sanitizePath(job, path):
         return sanitizedName
 
 
-def sanitizeRecursively(job, path):
+def sanitizeRecursively(path):
     path = os.path.abspath(path)
     sanitizations = {}
 
-    sanitizedName = sanitizePath(job, path)
+    sanitizedName = sanitizePath(path)
     if sanitizedName != path:
         path_key = unicodeToStr(
             unicodedata.normalize('NFC', path.decode('utf8')))
         sanitizations[path_key] = sanitizedName
     if os.path.isdir(sanitizedName):
         for f in os.listdir(sanitizedName):
-            sanitizations.update(sanitizeRecursively(job, os.path.join(sanitizedName, f)))
+            sanitizations.update(sanitizeRecursively(os.path.join(sanitizedName, f)))
 
     return sanitizations
 
@@ -107,7 +107,7 @@ def call(jobs):
                     job.set_status(255)
                     continue
                 job.pyprint("Scanning: ", path)
-                sanitizations = sanitizeRecursively(job, path)
+                sanitizations = sanitizeRecursively(path)
                 for oldfile, newfile in sanitizations.items():
                     job.pyprint(oldfile, " -> ", newfile)
                 job.pyprint("TEST DEBUG CLEAR DON'T INCLUDE IN RELEASE", file=sys.stderr)

--- a/src/MCPClient/lib/clientScripts/sanitize_names.py
+++ b/src/MCPClient/lib/clientScripts/sanitize_names.py
@@ -27,25 +27,18 @@ from shutil import move as rename
 import sys
 import unicodedata
 from unidecode import unidecode
-from archivematicaFunctions import unicodeToStr
+from archivematicaFunctions import strToUnicode, unicodeToStr
 
 VERSION = "1.10." + "$Id$".split(" ")[1]
 valid = "-_.()" + string.ascii_letters + string.digits
 replacementChar = "_"
 
 
-def transliterate(basename):
-    # We get a more meaningful name sanitization if UTF-8 names
-    # are correctly decoded to unistrings instead of str
-    try:
-        return unidecode(basename.decode('utf-8'))
-    except UnicodeDecodeError:
-        return unidecode(basename)
-
-
 def sanitizeName(basename):
     ret = ""
-    basename = transliterate(basename)
+    # We get a more meaningful name sanitization if UTF-8 names
+    # are correctly decoded to unistrings instead of str
+    basename = unidecode(strToUnicode(basename))
     for c in basename:
         if c in valid:
             ret += c

--- a/src/MCPClient/lib/clientScripts/sanitize_object_names.py
+++ b/src/MCPClient/lib/clientScripts/sanitize_object_names.py
@@ -53,7 +53,7 @@ def sanitize_object_names(job, objectsDirectory, sipUUID, date, groupType, group
                 transfer=transfer_mdl).all()
 
     # Sanitize objects on disk
-    sanitizations = sanitize_names.sanitizeRecursively(job, objectsDirectory)
+    sanitizations = sanitize_names.sanitizeRecursively(objectsDirectory)
     for oldfile, newfile in sanitizations.items():
         logger.info('sanitizations: %s -> %s', oldfile, newfile)
 

--- a/src/MCPClient/lib/clientScripts/sanitize_sip_name.py
+++ b/src/MCPClient/lib/clientScripts/sanitize_sip_name.py
@@ -56,7 +56,7 @@ def call(jobs):
                     job.pyprint("invalid unit type: ", unitType, file=sys.stderr)
                     job.set_status(1)
                     continue
-                dst = sanitizePath(job, SIPDirectory)
+                dst = sanitizePath(SIPDirectory)
                 if SIPDirectory != dst:
                     dst = dst.replace(sharedDirectoryPath, "%sharedPath%", 1) + "/"
                     job.pyprint(SIPDirectory.replace(sharedDirectoryPath, "%sharedPath%", 1) + " -> " + dst)

--- a/src/MCPClient/tests/test_sanitize.py
+++ b/src/MCPClient/tests/test_sanitize.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 
 from django.test import TestCase
+import pytest
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.abspath(os.path.join(THIS_DIR, '../lib/clientScripts')))
@@ -13,6 +14,7 @@ sys.path.append(os.path.abspath(os.path.join(THIS_DIR, '../lib/clientScripts')))
 from main.models import Event, File, Transfer
 
 from job import Job
+import sanitize_names
 import sanitize_object_names
 
 
@@ -76,3 +78,11 @@ class TestSanitize(TestCase):
         finally:
             # Delete files
             shutil.rmtree(transfer_path)
+
+
+@pytest.mark.parametrize("basename, expected_name", [
+    ("helloworld", "helloworld"),
+    (u"a\x80b", "ab"),
+])
+def test_sanitizeName(basename, expected_name):
+    assert sanitize_names.sanitizeName(basename) == expected_name


### PR DESCRIPTION
While looking at https://github.com/wellcometrust/platform/issues/3395, I noticed that the `sanitizeName()` method is constructing strings in quite an inefficient way. There’s also a bug in `transliterate()` – if passed a string like `u'\x80'`, it throws a Unicode error.

This patch:

* Fixes the bug caused by `transliterate()` by replacing it with a dedicated function for coercing to Unicode
* Replaces `sanitizeName()` with a regex-based solution that’s at least twice as faster (with more gains the longer the strings)

I don’t know how much of a difference it will make, but as a hot function in this script we might as well take the low-hanging perf fruit.

We could upstream this for https://github.com/artefactual/archivematica/issues/789

Attached is a test case that shows the output of the old and new functions are the same (modulo bugfix), and the regex-based version is faster: [create_examples.py](https://github.com/wellcometrust/archivematica/files/2988067/create_examples.txt)


