### PR TITLE
Print some commit information at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Wellcome specific
 secrets.zip
+.releases
 
 *.py[co]
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ ACCOUNT_ID = 299497370133
 #   $2 - Name of the Dockerfile in the src directory
 #
 define build_image
-	$(DOCKER_RUN) --dind -- $(IMAGE_BUILDER_IMAGE) --name=$(1) --path=src/$(2).Dockerfile
+	$(DOCKER_RUN) --dind -- $(IMAGE_BUILDER_IMAGE) \
+		--name=$(1) \
+		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
+		--path=src/$(2).Dockerfile
 endef
 
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ACCOUNT_ID = 299497370133
 define build_image
 	$(DOCKER_RUN) --dind -- $(IMAGE_BUILDER_IMAGE) \
 		--name=$(1) \
-		--build-arg GIT_COMMIT=$(shell git rev-parse HEAD) \
+		--build-arg GIT_COMMIT="$(shell git log -1 --pretty=format:'%h -- %ai -- %an -- %s')" \
 		--path=src/$(2).Dockerfile
 endef
 

--- a/src/MCPClient.Dockerfile
+++ b/src/MCPClient.Dockerfile
@@ -28,7 +28,10 @@ COPY MCPClient/ /src/MCPClient/
 COPY archivematicaCommon/lib/externals/fido/ /usr/lib/archivematica/archivematicaCommon/externals/fido/
 COPY archivematicaCommon/lib/externals/fiwalk_plugins/ /usr/lib/archivematica/archivematicaCommon/externals/fiwalk_plugins/
 
-
 USER archivematica
 
-ENTRYPOINT ["/src/MCPClient/lib/archivematicaClient.py"]
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+COPY run_mcpclient.sh /
+
+ENTRYPOINT ["/run_mcpclient.sh"]

--- a/src/MCPServer.Dockerfile
+++ b/src/MCPServer.Dockerfile
@@ -42,4 +42,8 @@ RUN set -ex \
 
 USER archivematica
 
-ENTRYPOINT ["/src/MCPServer/lib/archivematicaMCP.py"]
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+COPY run_mcpserver.sh /
+
+ENTRYPOINT ["/run_mcpserver.sh"]

--- a/src/dashboard.Dockerfile
+++ b/src/dashboard.Dockerfile
@@ -61,4 +61,8 @@ RUN env \
 
 EXPOSE 8000
 
-ENTRYPOINT ["/usr/local/bin/gunicorn", "--config=/etc/archivematica/dashboard.gunicorn-config.py", "wsgi:application"]
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+COPY run_dashboard.sh /
+
+ENTRYPOINT ["/run_dashboard.sh"]

--- a/src/run_dashboard.sh
+++ b/src/run_dashboard.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+echo "== WELLCOME: starting version $GIT_COMMIT =="
+
+/usr/local/bin/gunicorn --config=/etc/archivematica/dashboard.gunicorn-config.py wsgi:application $@

--- a/src/run_mcpclient.sh
+++ b/src/run_mcpclient.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+echo "== WELLCOME: starting version $GIT_COMMIT =="
+
+/src/MCPClient/lib/archivematicaClient.py $@

--- a/src/run_mcpserver.sh
+++ b/src/run_mcpserver.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+echo "== WELLCOME: starting version $GIT_COMMIT =="
+
+/src/MCPServer/lib/archivematicaMCP.py $@


### PR DESCRIPTION
This adds an extra log when Archivematica starts up:

```
== WELLCOME: starting version dba85c5d -- 2019-03-21 10:39:58 +0000 -- Alex Chan -- Print the Git commit hash at startup ==
```

This is a temporary measure that should make it easier for us to tell what version of the code we were running at a particular time.