### PR TITLE
Don't require transfer name for zipfile

### DIFF
--- a/src/dashboard/frontend/app/front_page/transfer_browser.html
+++ b/src/dashboard/frontend/app/front_page/transfer_browser.html
@@ -14,7 +14,7 @@
   <div class="help-block">{{ "Transfer type" | translate }}</div>
   </div>
 
-  <div class="col-xs-2" ng-if="vm.transfer.type !== 'zipped bag'">
+  <div class="col-xs-2" ng-if="vm.transfer.type !== 'zipped bag' && vm.transfer.type !== 'zipfile'">
   <input class="form-control" ng-model="vm.transfer.name"/>
   <div class="help-block">{{ "Transfer name" | translate }}</div>
   </div>

--- a/src/dashboard/frontend/app/header/header.controller.js
+++ b/src/dashboard/frontend/app/header/header.controller.js
@@ -41,7 +41,7 @@ class HeaderController {
   enable_submit_button() {
     // It's legal for "zipped bag" transfers to have no title,
     // since the final title is based on the name of the bag itself.
-    if (this.transfer.type !== 'zipped bag' && !this.transfer.name) {
+    if (this.transfer.type !== 'zipped bag' && this.transfer.type !== 'zipfile' && !this.transfer.name) {
       return false;
     }
 

--- a/src/dashboard/frontend/app/services/transfer_browser_transfer.service.js
+++ b/src/dashboard/frontend/app/services/transfer_browser_transfer.service.js
@@ -46,7 +46,13 @@ class TransferBrowserTransfer {
   start() {
     // If this is a zipped bag, then there will be no transfer name;
     // give it a dummy name instead.
-    let name = this.type === 'zipped bag' ? 'ZippedBag' : this.name;
+    let name = this.name;
+    if (this.type === 'zipped bag') {
+      name = 'ZippedBag';
+    } else if (this.type == 'zipfile') {
+      name = 'ZipFile';
+    }
+
     let _self = this;
 
     let payload = {


### PR DESCRIPTION
For https://github.com/wellcometrust/platform/issues/3556 - don't display transfer name field when zipfile is selected.