### PR TITLE
Ensure processing config is preserved with zipfile

### DIFF
--- a/src/MCPClient/lib/clientScripts/extract_zipped_transfer.py
+++ b/src/MCPClient/lib/clientScripts/extract_zipped_transfer.py
@@ -34,7 +34,7 @@ from django.db import transaction
 from main.models import Transfer
 
 # archivematicaCommon
-from archivematicaFunctions import str2bool
+from fileOperations import get_extract_dir_name
 from executeOrRunSubProcess import executeOrRun
 
 
@@ -88,16 +88,9 @@ def call(jobs):
                 isBag = args.bag
 
                 basename = os.path.basename(target)
-                basename = basename[: basename.rfind(".")]
-
                 destinationDirectory = os.path.join(processingDirectory, basename)
 
-                # trim off '.tar' if present (os.path.basename doesn't deal well with '.tar.gz')
-                try:
-                    tar_extension_position = destinationDirectory.rindex(".tar")
-                    destinationDirectory = destinationDirectory[:tar_extension_position]
-                except ValueError:
-                    pass
+                destinationDirectory = get_extract_dir_name(destinationDirectory)
 
                 zipLocation = os.path.join(
                     processingDirectory, os.path.basename(target)

--- a/src/MCPServer/tests/test_package.py
+++ b/src/MCPServer/tests/test_package.py
@@ -1,6 +1,17 @@
 import pytest
 
-from package import _determine_transfer_paths
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
+from main.models import Transfer
+
+from package import (
+    _determine_transfer_paths,
+    _move_to_internal_shared_dir,
+    _pad_destination_filepath_if_it_already_exists,
+)
 
 
 @pytest.mark.parametrize(
@@ -40,3 +51,80 @@ def test__determine_transfer_paths(name, path, tmpdir, expected):
     assert results[0] == expected[0], "name mismatch"
     assert results[1] == expected[1], "path mismatch"
     assert results[2] == expected[2], "tmpdir mismatch"
+
+
+class TestPadDestinationFilePath:
+    def test_zipfile_does_not_exist(self, tmp_path):
+        transfer_path = tmp_path / "transfer.zip"
+        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
+        assert padded_path == str(transfer_path)
+
+    def test_zipfile_is_padded_if_exists(self, tmp_path):
+        transfer_path = tmp_path / "transfer.zip"
+        transfer_path.touch()
+        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
+        assert padded_path == str(tmp_path / "transfer_1.zip")
+
+    def test_dir_does_not_exist(self, tmp_path):
+        transfer_path = tmp_path / "transfer/"
+        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
+        assert padded_path == str(transfer_path)
+
+    def test_dir_is_padded_if_exists(self, tmp_path):
+        transfer_path = tmp_path / "transfer/"
+        transfer_path.mkdir()
+        padded_path = _pad_destination_filepath_if_it_already_exists(str(transfer_path))
+        assert padded_path == str(tmp_path / "transfer_1")
+
+
+@pytest.fixture
+def transfer():
+    return Transfer.objects.create()
+
+
+@pytest.fixture
+def processing_dir(tmp_path):
+    proc_dir = tmp_path / "processing"
+    proc_dir.mkdir()
+    return proc_dir
+
+
+@pytest.mark.django_db
+class TestMoveToInternalSharedDir:
+    def test_move_dir(self, tmp_path, processing_dir, transfer):
+        filepath = tmp_path / "transfer"
+        filepath.mkdir()
+
+        _move_to_internal_shared_dir(str(filepath), str(processing_dir), transfer)
+
+        transfer.refresh_from_db()
+        dest_path = processing_dir / "transfer"
+        assert dest_path.is_dir()
+        assert Path(transfer.currentlocation) == dest_path
+
+    def test_move_file(self, tmp_path, processing_dir, transfer):
+        filepath = tmp_path / "transfer.zip"
+        filepath.touch()
+
+        _move_to_internal_shared_dir(str(filepath), str(processing_dir), transfer)
+
+        dest_path = processing_dir / "transfer.zip"
+        assert dest_path.is_file()
+        assert (processing_dir / "transfer").is_dir()
+
+        transfer.refresh_from_db()
+        assert Path(transfer.currentlocation) == dest_path
+
+    def test_move_processing_config_with_zipfile(
+        self, tmp_path, processing_dir, transfer
+    ):
+        filepath = tmp_path / "transfer.zip"
+        filepath.touch()
+
+        config = tmp_path / "processingMCP.xml"
+        config.touch()
+
+        _move_to_internal_shared_dir(str(filepath), str(processing_dir), transfer)
+
+        config_dest = processing_dir / "transfer/processingMCP.xml"
+        assert config_dest.is_file()

--- a/src/archivematicaCommon/lib/fileOperations.py
+++ b/src/archivematicaCommon/lib/fileOperations.py
@@ -394,3 +394,23 @@ def findFileInNormalizationCSV(
                 file=sys.stderr,
             )
             raise FindFileInNormalizatonCSVError(2)
+
+
+def get_extract_dir_name(filename):
+    """
+    Given the name of a compressed file, return the stem directory name into
+    which it should be extracted.
+
+    e.g. transfer1.zip will be extracted into transfer1
+         transfer2.tar.gz will be extracted into transfer2
+    """
+    extract_dir = filename[: filename.rfind(".")]
+
+    # trim off '.tar' if present
+    try:
+        tar_extension_position = extract_dir.rindex(".tar")
+        extract_dir = extract_dir[:tar_extension_position]
+    except ValueError:
+        pass
+
+    return extract_dir

--- a/src/archivematicaCommon/tests/test_file_operations.py
+++ b/src/archivematicaCommon/tests/test_file_operations.py
@@ -1,0 +1,10 @@
+import pytest
+
+from fileOperations import get_extract_dir_name
+
+
+@pytest.mark.parametrize(
+    "filename,dirname", [("test.zip", "test"), ("test.tar.gz", "test")]
+)
+def test_get_extract_dir_name(filename, dirname):
+    assert get_extract_dir_name(filename) == dirname


### PR DESCRIPTION
This is a local version of https://github.com/artefactual/archivematica/pull/1446 so we can get https://github.com/wellcometrust/platform/issues/3679 up and running sooner

This ensures the processing config is copied across when a zipfile package is moved to an internal Archivematica directory. Some tidyups and tests have been added.