### PR TITLE
Micro-optimisations to validate_file.py

### DIFF
--- a/src/MCPClient/lib/clientScripts/validate_file.py
+++ b/src/MCPClient/lib/clientScripts/validate_file.py
@@ -40,7 +40,7 @@ SUCCESS_CODE = 0
 FAIL_CODE = 1
 NOT_DERIVATIVE_CODE = 0
 NO_RULES_CODE = 0
-DERIVATIVE_TYPES = ("preservation", "access")
+DERIVATIVE_TYPES = {"preservation", "access"}
 
 
 def main(job, file_path, file_uuid, sip_uuid, shared_path, file_type):
@@ -95,11 +95,11 @@ class Validator(object):
         rules = self._get_rules()
         if not rules:
             return NO_RULES_CODE
-        rule_outputs = []
+
         for rule in rules:
-            rule_outputs.append(self._execute_rule_command(rule))
-        if "failed" in rule_outputs:
-            return FAIL_CODE
+            if self._execute_rule_command(rule) == "failed":
+                return FAIL_CODE
+
         return SUCCESS_CODE
 
     def _get_rules(self):


### PR DESCRIPTION
I was waiting for this task to finish, so went to stare at the code for a bit. Spotted two tiny improvements:

*   We run `if file_type in DERIVATIVE_TYPES` when we first validate; checking for set inclusion is faster than a tuple -- O(1), not O(n).

    In practice it's unlikely to make a noticeable difference for a collection of two elements, but it sets precedent for elsewhere.

*   Rather than accumulating the results of _execute_rule_command() in a list, inspect them one-by-one.

    This won't have any effect on a file that passes validation, but if a file fails validation it'll exit on the first failure, and skip running unnecessary checks.