### PR TITLE
Include UUID in SIP path created by dashboard

### DIFF
--- a/src/dashboard/src/components/filesystem_ajax/views.py
+++ b/src/dashboard/src/components/filesystem_ajax/views.py
@@ -385,7 +385,7 @@ def _create_arranged_sip(staging_sip_path, files, sip_uuid):
         "watchedDirectories",
         "SIPCreation",
         "SIPsUnderConstruction",
-        sip_name,
+        "%s-%s" % (sip_name, sip_uuid),
     )
     currentpath = sip_path.replace(shared_dir, "%sharedPath%", 1) + "/"
     sip_path = helpers.pad_destination_filepath_if_it_already_exists(sip_path)


### PR DESCRIPTION
This ensures the SIP UUID generated by the dashboard SIP creation process and linked to the files in the SIP, is preserved when MCP Server picks it up - otherwise MCP Server will try to create its own SIP object with a new UUID and the files are not linked to it, resulting in an error during restructuring.

Fixes https://github.com/wellcometrust/platform/issues/4021

See also https://github.com/artefactual/archivematica/pull/1534 PR into core Archivematica
